### PR TITLE
Change the domain and TLD indices in values[]

### DIFF
--- a/serversetup.sh
+++ b/serversetup.sh
@@ -48,8 +48,8 @@ EOF
     read -p "Enter your External IP Address (or range):  " -r extIP
 
     IFS="." read -ra values <<< "$primary_domain"
-    dName=${values[1]}
-    toplevel=${values[2]}
+    dName=${values[0]}
+    toplevel=${values[1]}
     extip1=$(ip a |grep -E -iv '\slo|forever|eth0:1' | grep "inet" |cut -d" " -f6 |cut -d"/" -f1)
     cat <<-EOF > /etc/hosts
 127.0.1.1 $primary_hostname $primary_domain


### PR DESCRIPTION
This makes more sense for `domain.com` rather than inputing `www.domain.com` (especially with support for LetsEncrypt wildcard certs) - it is not clear from the code or the instructions. I have never seen a hostname `www.domain` which is what the instructions seem to be asking for

A better solution might be to do a negative index, ie. `[-2]` and `[-1]`

I have tested this modification live on an assessment